### PR TITLE
[Documentation] Mention output file path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ apply plugin: "com.vanniktech.dependency.graph.generator"
 
 ## Usage
 
-By default this plugin will generate a `generateDependencyGraph` task that can be used to generate a dependency graph that could look like this. This graph was generated from my [chess clock app](https://play.google.com/store/apps/details?id=com.vanniktech.chessclock).
+By default this plugin will generate a `generateDependencyGraph` task that can be used to generate a dependency graph at location `yourmodule/build/reports/dependency-graph` that could look like this generated graph from my [chess clock app](https://play.google.com/store/apps/details?id=com.vanniktech.chessclock). The graph is generated in `.png`, `.svg` & `.dot` format.
 
 ![Example graph.](example.png)
 


### PR DESCRIPTION
### Summary
The documentation doesn't mention the path of the output report for the dependency graph which is hard to find. I've added it now so someone else doesn't have to trip to google & issues to see where it will be generated. 